### PR TITLE
11 add real content to about and privacy pages

### DIFF
--- a/app/(content)/imprint/page.md
+++ b/app/(content)/imprint/page.md
@@ -1,0 +1,27 @@
+# Impressum
+
+Protohaus gGmbH  
+Nordstraße 40a  
+38106 Braunschweig
+
+**Vertreten durch:**  
+Chris Töppe
+
+## Kontakt
+
+Telefon: 053134896170  
+E-Mail: info@protohaus.org
+
+## Umsatzsteuer-ID
+
+Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz:  
+DE 303 775 377
+
+## EU-Streitschlichtung
+
+Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: [https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/).  
+Unsere E-Mail-Adresse finden Sie oben im Impressum.
+
+## Verbraucherstreitbeilegung/Universalschlichtungsstelle
+
+Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.

--- a/app/(content)/layout.tsx
+++ b/app/(content)/layout.tsx
@@ -3,7 +3,7 @@ import { PropsWithChildren } from 'react'
 export default function ContentPagesLayout({ children }: PropsWithChildren) {
   return (
     <main className="flex flex-col items-center">
-      <article className="max-w-screen-lg prose lg:prose-xl mx-6">
+      <article className="max-w-screen-lg prose lg:prose-xl mx-6 my-[5vh]">
         {children}
       </article>
     </main>

--- a/app/(content)/layout.tsx
+++ b/app/(content)/layout.tsx
@@ -2,8 +2,8 @@ import { PropsWithChildren } from 'react'
 
 export default function ContentPagesLayout({ children }: PropsWithChildren) {
   return (
-    <main className="flex flex-col items-center">
-      <article className="max-w-screen-lg prose lg:prose-xl mx-6 my-[5vh]">
+    <main className="flex flex-col items-center w-full">
+      <article className="prose w-full max-w-screen-lg md:prose-lg px-4 md:px-6 py-8 md:py-[5vh]">
         {children}
       </article>
     </main>

--- a/app/(content)/privacy/page.md
+++ b/app/(content)/privacy/page.md
@@ -1,34 +1,6 @@
-# Impressum
-
-Protohaus gGmbH  
-Nordstraße 40a  
-38106 Braunschweig
-
-**Vertreten durch:**  
-Chris Töppe
-
-## Kontakt
-
-Telefon: 053134896170  
-E-Mail: info@protohaus.org
-
-## Umsatzsteuer-ID
-
-Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz:  
-DE 303 775 377
-
-## EU-Streitschlichtung
-
-Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: [https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/).  
-Unsere E-Mail-Adresse finden Sie oben im Impressum.
-
-## Verbraucherstreitbeilegung/Universalschlichtungsstelle
-
-Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
-
 # Datenschutzerklärung
 
-## 1\. Datenschutz auf einen Blick
+## 1 Datenschutz auf einen Blick
 
 ### Allgemeine Hinweise
 
@@ -56,7 +28,7 @@ Sie haben jederzeit das Recht, unentgeltlich Auskunft über Herkunft, Empfänger
 
 Hierzu sowie zu weiteren Fragen zum Thema Datenschutz können Sie sich jederzeit an uns wenden.
 
-## 2\. Hosting
+## 2 Hosting
 
 Wir hosten die Inhalte unserer Website in Europa, um den Datenschutzanforderungen bestmöglich gerecht zu werden.
 
@@ -64,7 +36,7 @@ Wir hosten die Inhalte unserer Website in Europa, um den Datenschutzanforderunge
 
 Wir haben einen Vertrag über Auftragsverarbeitung (AVV) zur Nutzung der Hosting-Dienste geschlossen. Hierbei handelt es sich um einen datenschutzrechtlich vorgeschriebenen Vertrag, der gewährleistet, dass personenbezogene Daten unserer Websitebesucher nur nach unseren Weisungen und unter Einhaltung der DSGVO verarbeitet werden.
 
-## 3\. Allgemeine Hinweise und Pflichtinformationen
+## 3 Allgemeine Hinweise und Pflichtinformationen
 
 ### Datenschutz
 
@@ -138,7 +110,7 @@ Diese Seite nutzt aus Sicherheitsgründen und zum Schutz der Übertragung vertra
 
 Wenn die SSL- bzw. TLS-Verschlüsselung aktiviert ist, können die Daten, die Sie an uns übermitteln, nicht von Dritten mitgelesen werden.
 
-## 4\. Datenerfassung auf dieser Website
+## 4 Datenerfassung auf dieser Website
 
 ### Server-Log-Dateien
 
@@ -163,7 +135,7 @@ Die Verarbeitung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. b DSG
 
 Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (z.B. nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen - insbesondere gesetzliche Aufbewahrungsfristen - bleiben unberührt.
 
-## 5\. Kartenmaterial
+## 5 Kartenmaterial
 
 ### Nutzung von MapTiler
 

--- a/app/(content)/privacy/page.md
+++ b/app/(content)/privacy/page.md
@@ -1,67 +1,178 @@
 # Impressum
 
-**Angaben gemäß § 5 TMG**
+Protohaus gGmbH  
+Nordstraße 40a  
+38106 Braunschweig
+
+**Vertreten durch:**  
+Chris Töppe
+
+## Kontakt
+
+Telefon: 053134896170  
+E-Mail: info@protohaus.org
+
+## Umsatzsteuer-ID
+
+Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz:  
+DE 303 775 377
+
+## EU-Streitschlichtung
+
+Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: [https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/).  
+Unsere E-Mail-Adresse finden Sie oben im Impressum.
+
+## Verbraucher­streit­beilegung/Universal­schlichtungs­stelle
+
+Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
+
+# Datenschutz­erklärung
+
+## 1\. Datenschutz auf einen Blick
+
+### Allgemeine Hinweise
+
+Die folgenden Hinweise geben einen einfachen Überblick darüber, was mit Ihren personenbezogenen Daten passiert, wenn Sie diese Website besuchen. Personenbezogene Daten sind alle Daten, mit denen Sie persönlich identifiziert werden können. Ausführliche Informationen zum Thema Datenschutz entnehmen Sie unserer unter diesem Text aufgeführten Datenschutzerklärung.
+
+### Datenerfassung auf dieser Website
+
+#### Wer ist verantwortlich für die Datenerfassung auf dieser Website?
+
+Die Datenverarbeitung auf dieser Website erfolgt durch den Websitebetreiber. Dessen Kontaktdaten können Sie dem Abschnitt „Hinweis zur Verantwortlichen Stelle“ in dieser Datenschutzerklärung entnehmen.
+
+#### Wie erfassen wir Ihre Daten?
+
+Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese mitteilen. Hierbei kann es sich z. B. um Daten handeln, die Sie in ein Kontaktformular eingeben.
+
+Andere Daten werden automatisch oder nach Ihrer Einwilligung beim Besuch der Website durch unsere IT-Systeme erfasst. Das sind vor allem technische Daten (z. B. Internetbrowser, Betriebssystem oder Uhrzeit des Seitenaufrufs). Die Erfassung dieser Daten erfolgt automatisch, sobald Sie diese Website betreten.
+
+#### Wofür nutzen wir Ihre Daten?
+
+Ein Teil der Daten wird erhoben, um eine fehlerfreie Bereitstellung der Website zu gewährleisten. Andere Daten können zur Analyse Ihres Nutzerverhaltens verwendet werden. Sofern über die Website Verträge geschlossen oder angebahnt werden können, werden die übermittelten Daten auch für Vertragsangebote, Bestellungen oder sonstige Auftragsanfragen verarbeitet.
+
+#### Welche Rechte haben Sie bezüglich Ihrer Daten?
+
+Sie haben jederzeit das Recht, unentgeltlich Auskunft über Herkunft, Empfänger und Zweck Ihrer gespeicherten personenbezogenen Daten zu erhalten. Sie haben außerdem ein Recht, die Berichtigung oder Löschung dieser Daten zu verlangen. Wenn Sie eine Einwilligung zur Datenverarbeitung erteilt haben, können Sie diese Einwilligung jederzeit für die Zukunft widerrufen. Außerdem haben Sie das Recht, unter bestimmten Umständen die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen. Des Weiteren steht Ihnen ein Beschwerderecht bei der zuständigen Aufsichtsbehörde zu.
+
+Hierzu sowie zu weiteren Fragen zum Thema Datenschutz können Sie sich jederzeit an uns wenden.
+
+## 2\. Hosting
+
+Wir hosten die Inhalte unserer Website in Europa, um den Datenschutzanforderungen bestmöglich gerecht zu werden.
+
+#### Auftragsverarbeitung
+
+Wir haben einen Vertrag über Auftragsverarbeitung (AVV) zur Nutzung der Hosting-Dienste geschlossen. Hierbei handelt es sich um einen datenschutzrechtlich vorgeschriebenen Vertrag, der gewährleistet, dass personenbezogene Daten unserer Websitebesucher nur nach unseren Weisungen und unter Einhaltung der DSGVO verarbeitet werden.
+
+## 3\. Allgemeine Hinweise und Pflicht­informationen
+
+### Datenschutz
+
+Die Betreiber dieser Seiten nehmen den Schutz Ihrer persönlichen Daten sehr ernst. Wir behandeln Ihre personenbezogenen Daten vertraulich und entsprechend den gesetzlichen Datenschutzvorschriften sowie dieser Datenschutzerklärung.
+
+Wenn Sie diese Website benutzen, werden verschiedene personenbezogene Daten erhoben. Personenbezogene Daten sind Daten, mit denen Sie persönlich identifiziert werden können. Die vorliegende Datenschutzerklärung erläutert, welche Daten wir erheben und wofür wir sie nutzen. Sie erläutert auch, wie und zu welchem Zweck das geschieht.
+
+Wir weisen darauf hin, dass die Datenübertragung im Internet (z. B. bei der Kommunikation per E-Mail) Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.
+
+### Hinweis zur verantwortlichen Stelle
+
+Die verantwortliche Stelle für die Datenverarbeitung auf dieser Website ist:
 
 Protohaus gGmbH  
 Nordstraße 40a  
 38106 Braunschweig
 
-Handelsregister: HRB 205645  
-Registergericht: Amtsgericht Braunschweig
-
-**Vertreten durch:**  
-Herrn Chris Töppe
-
-**Kontakt**  
-Telefon: 0531 34896170  
+Telefon: 053134896170  
 E-Mail: info@protohaus.org
 
-# Datenschutzerklärung
+Verantwortliche Stelle ist die natürliche oder juristische Person, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten (z. B. Namen, E-Mail-Adressen o. Ä.) entscheidet.
 
-**Verantwortlicher im Sinne der Datenschutzgesetze, insbesondere der EU-Datenschutzgrundverordnung (DSGVO):**
+### Speicherdauer
 
-Protohaus gGmbH  
-Nordstraße 40a  
-38106 Braunschweig  
-Telefon: 0531 34896170  
-E-Mail: info@protohaus.org
+Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer genannt wurde, verbleiben Ihre personenbezogenen Daten bei uns, bis der Zweck für die Datenverarbeitung entfällt. Wenn Sie ein berechtigtes Löschersuchen geltend machen oder eine Einwilligung zur Datenverarbeitung widerrufen, werden Ihre Daten gelöscht, sofern wir keine anderen rechtlich zulässigen Gründe für die Speicherung Ihrer personenbezogenen Daten haben (z. B. steuer- oder handelsrechtliche Aufbewahrungsfristen); im letztgenannten Fall erfolgt die Löschung nach Fortfall dieser Gründe.
 
-## Allgemeine Hinweise
+### Allgemeine Hinweise zu den Rechtsgrundlagen der Datenverarbeitung auf dieser Website
 
-Wir nehmen den Schutz Ihrer persönlichen Daten sehr ernst. Diese Datenschutzerklärung informiert Sie darüber, welche Daten wir erheben und wie wir sie verarbeiten.
+Sofern Sie in die Datenverarbeitung eingewilligt haben, verarbeiten wir Ihre personenbezogenen Daten auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO bzw. Art. 9 Abs. 2 lit. a DSGVO, sofern besondere Datenkategorien nach Art. 9 Abs. 1 DSGVO verarbeitet werden. Im Falle einer ausdrücklichen Einwilligung in die Übertragung personenbezogener Daten in Drittstaaten erfolgt die Datenverarbeitung außerdem auf Grundlage von Art. 49 Abs. 1 lit. a DSGVO. Sofern Sie in die Speicherung von Cookies oder in den Zugriff auf Informationen in Ihr Endgerät (z. B. via Device-Fingerprinting) eingewilligt haben, erfolgt die Datenverarbeitung zusätzlich auf Grundlage von § 25 Abs. 1 TDDDG. Die Einwilligung ist jederzeit widerrufbar. Sind Ihre Daten zur Vertragserfüllung oder zur Durchführung vorvertraglicher Maßnahmen erforderlich, verarbeiten wir Ihre Daten auf Grundlage des Art. 6 Abs. 1 lit. b DSGVO. Des Weiteren verarbeiten wir Ihre Daten, sofern diese zur Erfüllung einer rechtlichen Verpflichtung erforderlich sind auf Grundlage von Art. 6 Abs. 1 lit. c DSGVO. Die Datenverarbeitung kann ferner auf Grundlage unseres berechtigten Interesses nach Art. 6 Abs. 1 lit. f DSGVO erfolgen. Über die jeweils im Einzelfall einschlägigen Rechtsgrundlagen wird in den folgenden Absätzen dieser Datenschutzerklärung informiert.
 
-### 1. Hosting
+### Empfänger von personenbezogenen Daten
 
-Unsere Website wird von **Vercel.com** gehostet. Wir bemühen uns, dass alle Daten auf Servern innerhalb der Europäischen Union gehostet werden.
+Im Rahmen unserer Geschäftstätigkeit arbeiten wir mit verschiedenen externen Stellen zusammen. Dabei ist teilweise auch eine Übermittlung von personenbezogenen Daten an diese externen Stellen erforderlich. Wir geben personenbezogene Daten nur dann an externe Stellen weiter, wenn dies im Rahmen einer Vertragserfüllung erforderlich ist, wenn wir gesetzlich hierzu verpflichtet sind (z. B. Weitergabe von Daten an Steuerbehörden), wenn wir ein berechtigtes Interesse nach Art. 6 Abs. 1 lit. f DSGVO an der Weitergabe haben oder wenn eine sonstige Rechtsgrundlage die Datenweitergabe erlaubt. Beim Einsatz von Auftragsverarbeitern geben wir personenbezogene Daten unserer Kunden nur auf Grundlage eines gültigen Vertrags über Auftragsverarbeitung weiter. Im Falle einer gemeinsamen Verarbeitung wird ein Vertrag über gemeinsame Verarbeitung geschlossen.
 
-### 2. Kartenmaterial
+### Widerruf Ihrer Einwilligung zur Datenverarbeitung
 
-Für unsere interaktiven Karten verwenden wir den Dienst **maptiler.com**, der ebenfalls datenschutzkonform arbeitet.
+Viele Datenverarbeitungsvorgänge sind nur mit Ihrer ausdrücklichen Einwilligung möglich. Sie können eine bereits erteilte Einwilligung jederzeit widerrufen. Die Rechtmäßigkeit der bis zum Widerruf erfolgten Datenverarbeitung bleibt vom Widerruf unberührt.
 
-### 3. Keine Verwendung von Tracking
+### Widerspruchsrecht gegen die Datenerhebung in besonderen Fällen sowie gegen Direktwerbung (Art. 21 DSGVO)
 
-Wir verwenden derzeit keine Analysetools, Tracking oder andere externe Anbieter, die personenbezogene Daten erheben.
+WENN DIE DATENVERARBEITUNG AUF GRUNDLAGE VON ART. 6 ABS. 1 LIT. E ODER F DSGVO ERFOLGT, HABEN SIE JEDERZEIT DAS RECHT, AUS GRÜNDEN, DIE SICH AUS IHRER BESONDEREN SITUATION ERGEBEN, GEGEN DIE VERARBEITUNG IHRER PERSONENBEZOGENEN DATEN WIDERSPRUCH EINZULEGEN; DIES GILT AUCH FÜR EIN AUF DIESE BESTIMMUNGEN GESTÜTZTES PROFILING. DIE JEWEILIGE RECHTSGRUNDLAGE, AUF DENEN EINE VERARBEITUNG BERUHT, ENTNEHMEN SIE DIESER DATENSCHUTZERKLÄRUNG. WENN SIE WIDERSPRUCH EINLEGEN, WERDEN WIR IHRE BETROFFENEN PERSONENBEZOGENEN DATEN NICHT MEHR VERARBEITEN, ES SEI DENN, WIR KÖNNEN ZWINGENDE SCHUTZWÜRDIGE GRÜNDE FÜR DIE VERARBEITUNG NACHWEISEN, DIE IHRE INTERESSEN, RECHTE UND FREIHEITEN ÜBERWIEGEN ODER DIE VERARBEITUNG DIENT DER GELTENDMACHUNG, AUSÜBUNG ODER VERTEIDIGUNG VON RECHTSANSPRÜCHEN (WIDERSPRUCH NACH ART. 21 ABS. 1 DSGVO).
 
-### 4. Rechte der betroffenen Personen
+WERDEN IHRE PERSONENBEZOGENEN DATEN VERARBEITET, UM DIREKTWERBUNG ZU BETREIBEN, SO HABEN SIE DAS RECHT, JEDERZEIT WIDERSPRUCH GEGEN DIE VERARBEITUNG SIE BETREFFENDER PERSONENBEZOGENER DATEN ZUM ZWECKE DERARTIGER WERBUNG EINZULEGEN; DIES GILT AUCH FÜR DAS PROFILING, SOWEIT ES MIT SOLCHER DIREKTWERBUNG IN VERBINDUNG STEHT. WENN SIE WIDERSPRECHEN, WERDEN IHRE PERSONENBEZOGENEN DATEN ANSCHLIESSEND NICHT MEHR ZUM ZWECKE DER DIREKTWERBUNG VERWENDET (WIDERSPRUCH NACH ART. 21 ABS. 2 DSGVO).
 
-Sie haben das Recht:
+### Beschwerde­recht bei der zuständigen Aufsichts­behörde
 
-- Auskunft über Ihre bei uns gespeicherten Daten zu erhalten (Art. 15 DSGVO).
-- Berichtigung falscher Daten (Art. 16 DSGVO).
-- Löschung Ihrer Daten, sofern diese nicht mehr erforderlich sind (Art. 17 DSGVO).
-- Einschränkung der Verarbeitung Ihrer Daten (Art. 18 DSGVO).
-- Widerspruch gegen die Verarbeitung Ihrer Daten (Art. 21 DSGVO).
-- Ihre Daten in einem strukturierten, gängigen und maschinenlesbaren Format zu erhalten (Art. 20 DSGVO).
+Im Falle von Verstößen gegen die DSGVO steht den Betroffenen ein Beschwerderecht bei einer Aufsichtsbehörde, insbesondere in dem Mitgliedstaat ihres gewöhnlichen Aufenthalts, ihres Arbeitsplatzes oder des Orts des mutmaßlichen Verstoßes zu. Das Beschwerderecht besteht unbeschadet anderweitiger verwaltungsrechtlicher oder gerichtlicher Rechtsbehelfe.
 
-**Kontakt für Datenschutzanfragen**  
-E-Mail: info@protohaus.org
+### Recht auf Daten­übertrag­barkeit
 
-Wenn Sie der Ansicht sind, dass die Verarbeitung Ihrer Daten gegen die DSGVO verstößt, haben Sie das Recht, sich bei einer Aufsichtsbehörde zu beschweren. Zuständige Behörde:
+Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung oder in Erfüllung eines Vertrags automatisiert verarbeiten, an sich oder an einen Dritten in einem gängigen, maschinenlesbaren Format aushändigen zu lassen. Sofern Sie die direkte Übertragung der Daten an einen anderen Verantwortlichen verlangen, erfolgt dies nur, soweit es technisch machbar ist.
 
-Niedersächsischer Landesbeauftragter für den Datenschutz  
-Prinzenstraße 5  
-30159 Hannover  
-Telefon: 0511 120-4500  
-E-Mail: poststelle@lfd.niedersachsen.de
+### Auskunft, Berichtigung und Löschung
 
-Stand: November 2024
+Sie haben im Rahmen der geltenden gesetzlichen Bestimmungen jederzeit das Recht auf unentgeltliche Auskunft über Ihre gespeicherten personenbezogenen Daten, deren Herkunft und Empfänger und den Zweck der Datenverarbeitung und ggf. ein Recht auf Berichtigung oder Löschung dieser Daten. Hierzu sowie zu weiteren Fragen zum Thema personenbezogene Daten können Sie sich jederzeit an uns wenden.
+
+### Recht auf Einschränkung der Verarbeitung
+
+Sie haben das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen. Hierzu können Sie sich jederzeit an uns wenden. Das Recht auf Einschränkung der Verarbeitung besteht in folgenden Fällen:
+
+- Wenn Sie die Richtigkeit Ihrer bei uns gespeicherten personenbezogenen Daten bestreiten, benötigen wir in der Regel Zeit, um dies zu überprüfen. Für die Dauer der Prüfung haben Sie das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+- Wenn die Verarbeitung Ihrer personenbezogenen Daten unrechtmäßig geschah/geschieht, können Sie statt der Löschung die Einschränkung der Datenverarbeitung verlangen.
+- Wenn wir Ihre personenbezogenen Daten nicht mehr benötigen, Sie sie jedoch zur Ausübung, Verteidigung oder Geltendmachung von Rechtsansprüchen benötigen, haben Sie das Recht, statt der Löschung die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+- Wenn Sie einen Widerspruch nach Art. 21 Abs. 1 DSGVO eingelegt haben, muss eine Abwägung zwischen Ihren und unseren Interessen vorgenommen werden. Solange noch nicht feststeht, wessen Interessen überwiegen, haben Sie das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
+
+Wenn Sie die Verarbeitung Ihrer personenbezogenen Daten eingeschränkt haben, dürfen diese Daten – von ihrer Speicherung abgesehen – nur mit Ihrer Einwilligung oder zur Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen oder zum Schutz der Rechte einer anderen natürlichen oder juristischen Person oder aus Gründen eines wichtigen öffentlichen Interesses der Europäischen Union oder eines Mitgliedstaats verarbeitet werden.
+
+### SSL- bzw. TLS-Verschlüsselung
+
+Diese Seite nutzt aus Sicherheitsgründen und zum Schutz der Übertragung vertraulicher Inhalte, wie zum Beispiel Bestellungen oder Anfragen, die Sie an uns als Seitenbetreiber senden, eine SSL- bzw. TLS-Verschlüsselung. Eine verschlüsselte Verbindung erkennen Sie daran, dass die Adresszeile des Browsers von „http://“ auf „https://“ wechselt und an dem Schloss-Symbol in Ihrer Browserzeile.
+
+Wenn die SSL- bzw. TLS-Verschlüsselung aktiviert ist, können die Daten, die Sie an uns übermitteln, nicht von Dritten mitgelesen werden.
+
+## 4\. Datenerfassung auf dieser Website
+
+### Server-Log-Dateien
+
+Der Provider der Seiten erhebt und speichert automatisch Informationen in so genannten Server-Log-Dateien, die Ihr Browser automatisch an uns übermittelt. Dies sind:
+
+- Browsertyp und Browserversion
+- verwendetes Betriebssystem
+- Referrer URL
+- Hostname des zugreifenden Rechners
+- Uhrzeit der Serveranfrage
+- IP-Adresse
+
+Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht vorgenommen.
+
+Die Erfassung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Der Websitebetreiber hat ein berechtigtes Interesse an der technisch fehlerfreien Darstellung und der Optimierung seiner Website – hierzu müssen die Server-Log-Files erfasst werden.
+
+### Anfrage per E-Mail, Telefon oder Telefax
+
+Wenn Sie uns per E-Mail, Telefon oder Telefax kontaktieren, wird Ihre Anfrage inklusive aller daraus hervorgehenden personenbezogenen Daten (Name, Anfrage) zum Zwecke der Bearbeitung Ihres Anliegens bei uns gespeichert und verarbeitet. Diese Daten geben wir nicht ohne Ihre Einwilligung weiter.
+
+Die Verarbeitung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO, sofern Ihre Anfrage mit der Erfüllung eines Vertrags zusammenhängt oder zur Durchführung vorvertraglicher Maßnahmen erforderlich ist. In allen übrigen Fällen beruht die Verarbeitung auf unserem berechtigten Interesse an der effektiven Bearbeitung der an uns gerichteten Anfragen (Art. 6 Abs. 1 lit. f DSGVO) oder auf Ihrer Einwilligung (Art. 6 Abs. 1 lit. a DSGVO) sofern diese abgefragt wurde; die Einwilligung ist jederzeit widerrufbar.
+
+Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (z. B. nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen – insbesondere gesetzliche Aufbewahrungsfristen – bleiben unberührt.
+
+## 5\. Kartenmaterial
+
+### Nutzung von MapTiler
+
+Unsere Website nutzt MapTiler, einen Dienst der MapTiler AG, Zugerstrasse 22, 6314 Unterägeri, Schweiz, um geografische Informationen ansprechend und informativ darzustellen.
+
+Damit die Funktionen von MapTiler bereitgestellt werden können, wird Ihre IP-Adresse an MapTiler übermittelt und vorübergehend für die Dauer Ihrer Sitzung gespeichert. MapTiler hostet seine Daten unter anderem auf Servern in der Europäischen Union, darunter Standorte wie Berlin, Düsseldorf, Frankfurt, Hamburg und München. Nach Angaben von MapTiler werden keine personenbezogenen Daten dauerhaft gespeichert oder an Dritte weitergegeben, und es erfolgt keine Analyse Ihres Nutzerverhaltens zu Werbezwecken.
+
+Die Nutzung von MapTiler erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Unser berechtigtes Interesse liegt in der ansprechenden Darstellung von geografischen Informationen für unsere Nutzer.
+
+MapTiler speichert die IP-Adresse maximal 20 Minuten, um sicherheitsrelevante Aktivitäten zu protokollieren und die Infrastruktur zu schützen. Laut MapTiler werden alle notwendigen technischen und organisatorischen Maßnahmen getroffen, um die Sicherheit und den Schutz Ihrer Daten zu gewährleisten. Dennoch können wir eine Datenübermittlung in Länder, die als unsichere Drittstaaten im Sinne der DSGVO gelten, nicht vollständig ausschließen.
+
+Weitere Informationen zur Datenverarbeitung durch MapTiler finden Sie in der Datenschutzerklärung von MapTiler: [https://www.maptiler.com/privacy-policy/](https://www.maptiler.com/privacy-policy/).

--- a/app/(content)/privacy/page.md
+++ b/app/(content)/privacy/page.md
@@ -22,11 +22,11 @@ DE 303 775 377
 Die Europäische Kommission stellt eine Plattform zur Online-Streitbeilegung (OS) bereit: [https://ec.europa.eu/consumers/odr/](https://ec.europa.eu/consumers/odr/).  
 Unsere E-Mail-Adresse finden Sie oben im Impressum.
 
-## Verbraucher­streit­beilegung/Universal­schlichtungs­stelle
+## Verbraucherstreitbeilegung/Universalschlichtungsstelle
 
 Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren vor einer Verbraucherschlichtungsstelle teilzunehmen.
 
-# Datenschutz­erklärung
+# Datenschutzerklärung
 
 ## 1\. Datenschutz auf einen Blick
 
@@ -42,9 +42,9 @@ Die Datenverarbeitung auf dieser Website erfolgt durch den Websitebetreiber. Des
 
 #### Wie erfassen wir Ihre Daten?
 
-Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese mitteilen. Hierbei kann es sich z. B. um Daten handeln, die Sie in ein Kontaktformular eingeben.
+Ihre Daten werden zum einen dadurch erhoben, dass Sie uns diese mitteilen. Hierbei kann es sich z.B. um Daten handeln, die Sie in ein Kontaktformular eingeben.
 
-Andere Daten werden automatisch oder nach Ihrer Einwilligung beim Besuch der Website durch unsere IT-Systeme erfasst. Das sind vor allem technische Daten (z. B. Internetbrowser, Betriebssystem oder Uhrzeit des Seitenaufrufs). Die Erfassung dieser Daten erfolgt automatisch, sobald Sie diese Website betreten.
+Andere Daten werden automatisch oder nach Ihrer Einwilligung beim Besuch der Website durch unsere IT-Systeme erfasst. Das sind vor allem technische Daten (z.B. Internetbrowser, Betriebssystem oder Uhrzeit des Seitenaufrufs). Die Erfassung dieser Daten erfolgt automatisch, sobald Sie diese Website betreten.
 
 #### Wofür nutzen wir Ihre Daten?
 
@@ -64,7 +64,7 @@ Wir hosten die Inhalte unserer Website in Europa, um den Datenschutzanforderunge
 
 Wir haben einen Vertrag über Auftragsverarbeitung (AVV) zur Nutzung der Hosting-Dienste geschlossen. Hierbei handelt es sich um einen datenschutzrechtlich vorgeschriebenen Vertrag, der gewährleistet, dass personenbezogene Daten unserer Websitebesucher nur nach unseren Weisungen und unter Einhaltung der DSGVO verarbeitet werden.
 
-## 3\. Allgemeine Hinweise und Pflicht­informationen
+## 3\. Allgemeine Hinweise und Pflichtinformationen
 
 ### Datenschutz
 
@@ -72,7 +72,7 @@ Die Betreiber dieser Seiten nehmen den Schutz Ihrer persönlichen Daten sehr ern
 
 Wenn Sie diese Website benutzen, werden verschiedene personenbezogene Daten erhoben. Personenbezogene Daten sind Daten, mit denen Sie persönlich identifiziert werden können. Die vorliegende Datenschutzerklärung erläutert, welche Daten wir erheben und wofür wir sie nutzen. Sie erläutert auch, wie und zu welchem Zweck das geschieht.
 
-Wir weisen darauf hin, dass die Datenübertragung im Internet (z. B. bei der Kommunikation per E-Mail) Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.
+Wir weisen darauf hin, dass die Datenübertragung im Internet (z.B. bei der Kommunikation per E-Mail) Sicherheitslücken aufweisen kann. Ein lückenloser Schutz der Daten vor dem Zugriff durch Dritte ist nicht möglich.
 
 ### Hinweis zur verantwortlichen Stelle
 
@@ -85,19 +85,19 @@ Nordstraße 40a
 Telefon: 053134896170  
 E-Mail: info@protohaus.org
 
-Verantwortliche Stelle ist die natürliche oder juristische Person, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten (z. B. Namen, E-Mail-Adressen o. Ä.) entscheidet.
+Verantwortliche Stelle ist die natürliche oder juristische Person, die allein oder gemeinsam mit anderen über die Zwecke und Mittel der Verarbeitung von personenbezogenen Daten (z.B. Namen, E-Mail-Adressen o. Ä.) entscheidet.
 
 ### Speicherdauer
 
-Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer genannt wurde, verbleiben Ihre personenbezogenen Daten bei uns, bis der Zweck für die Datenverarbeitung entfällt. Wenn Sie ein berechtigtes Löschersuchen geltend machen oder eine Einwilligung zur Datenverarbeitung widerrufen, werden Ihre Daten gelöscht, sofern wir keine anderen rechtlich zulässigen Gründe für die Speicherung Ihrer personenbezogenen Daten haben (z. B. steuer- oder handelsrechtliche Aufbewahrungsfristen); im letztgenannten Fall erfolgt die Löschung nach Fortfall dieser Gründe.
+Soweit innerhalb dieser Datenschutzerklärung keine speziellere Speicherdauer genannt wurde, verbleiben Ihre personenbezogenen Daten bei uns, bis der Zweck für die Datenverarbeitung entfällt. Wenn Sie ein berechtigtes Löschersuchen geltend machen oder eine Einwilligung zur Datenverarbeitung widerrufen, werden Ihre Daten gelöscht, sofern wir keine anderen rechtlich zulässigen Gründe für die Speicherung Ihrer personenbezogenen Daten haben (z.B. steuer- oder handelsrechtliche Aufbewahrungsfristen); im letztgenannten Fall erfolgt die Löschung nach Fortfall dieser Gründe.
 
 ### Allgemeine Hinweise zu den Rechtsgrundlagen der Datenverarbeitung auf dieser Website
 
-Sofern Sie in die Datenverarbeitung eingewilligt haben, verarbeiten wir Ihre personenbezogenen Daten auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO bzw. Art. 9 Abs. 2 lit. a DSGVO, sofern besondere Datenkategorien nach Art. 9 Abs. 1 DSGVO verarbeitet werden. Im Falle einer ausdrücklichen Einwilligung in die Übertragung personenbezogener Daten in Drittstaaten erfolgt die Datenverarbeitung außerdem auf Grundlage von Art. 49 Abs. 1 lit. a DSGVO. Sofern Sie in die Speicherung von Cookies oder in den Zugriff auf Informationen in Ihr Endgerät (z. B. via Device-Fingerprinting) eingewilligt haben, erfolgt die Datenverarbeitung zusätzlich auf Grundlage von § 25 Abs. 1 TDDDG. Die Einwilligung ist jederzeit widerrufbar. Sind Ihre Daten zur Vertragserfüllung oder zur Durchführung vorvertraglicher Maßnahmen erforderlich, verarbeiten wir Ihre Daten auf Grundlage des Art. 6 Abs. 1 lit. b DSGVO. Des Weiteren verarbeiten wir Ihre Daten, sofern diese zur Erfüllung einer rechtlichen Verpflichtung erforderlich sind auf Grundlage von Art. 6 Abs. 1 lit. c DSGVO. Die Datenverarbeitung kann ferner auf Grundlage unseres berechtigten Interesses nach Art. 6 Abs. 1 lit. f DSGVO erfolgen. Über die jeweils im Einzelfall einschlägigen Rechtsgrundlagen wird in den folgenden Absätzen dieser Datenschutzerklärung informiert.
+Sofern Sie in die Datenverarbeitung eingewilligt haben, verarbeiten wir Ihre personenbezogenen Daten auf Grundlage von Art. 6 Abs. 1 lit. a DSGVO bzw. Art. 9 Abs. 2 lit. a DSGVO, sofern besondere Datenkategorien nach Art. 9 Abs. 1 DSGVO verarbeitet werden. Im Falle einer ausdrücklichen Einwilligung in die Übertragung personenbezogener Daten in Drittstaaten erfolgt die Datenverarbeitung außerdem auf Grundlage von Art. 49 Abs. 1 lit. a DSGVO. Sofern Sie in die Speicherung von Cookies oder in den Zugriff auf Informationen in Ihr Endgerät (z.B. via Device-Fingerprinting) eingewilligt haben, erfolgt die Datenverarbeitung zusätzlich auf Grundlage von § 25 Abs. 1 TDDDG. Die Einwilligung ist jederzeit widerrufbar. Sind Ihre Daten zur Vertragserfüllung oder zur Durchführung vorvertraglicher Maßnahmen erforderlich, verarbeiten wir Ihre Daten auf Grundlage des Art. 6 Abs. 1 lit. b DSGVO. Des Weiteren verarbeiten wir Ihre Daten, sofern diese zur Erfüllung einer rechtlichen Verpflichtung erforderlich sind auf Grundlage von Art. 6 Abs. 1 lit. c DSGVO. Die Datenverarbeitung kann ferner auf Grundlage unseres berechtigten Interesses nach Art. 6 Abs. 1 lit. f DSGVO erfolgen. Über die jeweils im Einzelfall einschlägigen Rechtsgrundlagen wird in den folgenden Absätzen dieser Datenschutzerklärung informiert.
 
 ### Empfänger von personenbezogenen Daten
 
-Im Rahmen unserer Geschäftstätigkeit arbeiten wir mit verschiedenen externen Stellen zusammen. Dabei ist teilweise auch eine Übermittlung von personenbezogenen Daten an diese externen Stellen erforderlich. Wir geben personenbezogene Daten nur dann an externe Stellen weiter, wenn dies im Rahmen einer Vertragserfüllung erforderlich ist, wenn wir gesetzlich hierzu verpflichtet sind (z. B. Weitergabe von Daten an Steuerbehörden), wenn wir ein berechtigtes Interesse nach Art. 6 Abs. 1 lit. f DSGVO an der Weitergabe haben oder wenn eine sonstige Rechtsgrundlage die Datenweitergabe erlaubt. Beim Einsatz von Auftragsverarbeitern geben wir personenbezogene Daten unserer Kunden nur auf Grundlage eines gültigen Vertrags über Auftragsverarbeitung weiter. Im Falle einer gemeinsamen Verarbeitung wird ein Vertrag über gemeinsame Verarbeitung geschlossen.
+Im Rahmen unserer Geschäftstätigkeit arbeiten wir mit verschiedenen externen Stellen zusammen. Dabei ist teilweise auch eine Übermittlung von personenbezogenen Daten an diese externen Stellen erforderlich. Wir geben personenbezogene Daten nur dann an externe Stellen weiter, wenn dies im Rahmen einer Vertragserfüllung erforderlich ist, wenn wir gesetzlich hierzu verpflichtet sind (z.B. Weitergabe von Daten an Steuerbehörden), wenn wir ein berechtigtes Interesse nach Art. 6 Abs. 1 lit. f DSGVO an der Weitergabe haben oder wenn eine sonstige Rechtsgrundlage die Datenweitergabe erlaubt. Beim Einsatz von Auftragsverarbeitern geben wir personenbezogene Daten unserer Kunden nur auf Grundlage eines gültigen Vertrags über Auftragsverarbeitung weiter. Im Falle einer gemeinsamen Verarbeitung wird ein Vertrag über gemeinsame Verarbeitung geschlossen.
 
 ### Widerruf Ihrer Einwilligung zur Datenverarbeitung
 
@@ -109,11 +109,11 @@ WENN DIE DATENVERARBEITUNG AUF GRUNDLAGE VON ART. 6 ABS. 1 LIT. E ODER F DSGVO E
 
 WERDEN IHRE PERSONENBEZOGENEN DATEN VERARBEITET, UM DIREKTWERBUNG ZU BETREIBEN, SO HABEN SIE DAS RECHT, JEDERZEIT WIDERSPRUCH GEGEN DIE VERARBEITUNG SIE BETREFFENDER PERSONENBEZOGENER DATEN ZUM ZWECKE DERARTIGER WERBUNG EINZULEGEN; DIES GILT AUCH FÜR DAS PROFILING, SOWEIT ES MIT SOLCHER DIREKTWERBUNG IN VERBINDUNG STEHT. WENN SIE WIDERSPRECHEN, WERDEN IHRE PERSONENBEZOGENEN DATEN ANSCHLIESSEND NICHT MEHR ZUM ZWECKE DER DIREKTWERBUNG VERWENDET (WIDERSPRUCH NACH ART. 21 ABS. 2 DSGVO).
 
-### Beschwerde­recht bei der zuständigen Aufsichts­behörde
+### Beschwerderecht bei der zuständigen Aufsichtsbehörde
 
 Im Falle von Verstößen gegen die DSGVO steht den Betroffenen ein Beschwerderecht bei einer Aufsichtsbehörde, insbesondere in dem Mitgliedstaat ihres gewöhnlichen Aufenthalts, ihres Arbeitsplatzes oder des Orts des mutmaßlichen Verstoßes zu. Das Beschwerderecht besteht unbeschadet anderweitiger verwaltungsrechtlicher oder gerichtlicher Rechtsbehelfe.
 
-### Recht auf Daten­übertrag­barkeit
+### Recht auf Datenübertragbarkeit
 
 Sie haben das Recht, Daten, die wir auf Grundlage Ihrer Einwilligung oder in Erfüllung eines Vertrags automatisiert verarbeiten, an sich oder an einen Dritten in einem gängigen, maschinenlesbaren Format aushändigen zu lassen. Sofern Sie die direkte Übertragung der Daten an einen anderen Verantwortlichen verlangen, erfolgt dies nur, soweit es technisch machbar ist.
 
@@ -130,7 +130,7 @@ Sie haben das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen
 - Wenn wir Ihre personenbezogenen Daten nicht mehr benötigen, Sie sie jedoch zur Ausübung, Verteidigung oder Geltendmachung von Rechtsansprüchen benötigen, haben Sie das Recht, statt der Löschung die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
 - Wenn Sie einen Widerspruch nach Art. 21 Abs. 1 DSGVO eingelegt haben, muss eine Abwägung zwischen Ihren und unseren Interessen vorgenommen werden. Solange noch nicht feststeht, wessen Interessen überwiegen, haben Sie das Recht, die Einschränkung der Verarbeitung Ihrer personenbezogenen Daten zu verlangen.
 
-Wenn Sie die Verarbeitung Ihrer personenbezogenen Daten eingeschränkt haben, dürfen diese Daten – von ihrer Speicherung abgesehen – nur mit Ihrer Einwilligung oder zur Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen oder zum Schutz der Rechte einer anderen natürlichen oder juristischen Person oder aus Gründen eines wichtigen öffentlichen Interesses der Europäischen Union oder eines Mitgliedstaats verarbeitet werden.
+Wenn Sie die Verarbeitung Ihrer personenbezogenen Daten eingeschränkt haben, dürfen diese Daten - von ihrer Speicherung abgesehen - nur mit Ihrer Einwilligung oder zur Geltendmachung, Ausübung oder Verteidigung von Rechtsansprüchen oder zum Schutz der Rechte einer anderen natürlichen oder juristischen Person oder aus Gründen eines wichtigen öffentlichen Interesses der Europäischen Union oder eines Mitgliedstaats verarbeitet werden.
 
 ### SSL- bzw. TLS-Verschlüsselung
 
@@ -153,7 +153,7 @@ Der Provider der Seiten erhebt und speichert automatisch Informationen in so gen
 
 Eine Zusammenführung dieser Daten mit anderen Datenquellen wird nicht vorgenommen.
 
-Die Erfassung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Der Websitebetreiber hat ein berechtigtes Interesse an der technisch fehlerfreien Darstellung und der Optimierung seiner Website – hierzu müssen die Server-Log-Files erfasst werden.
+Die Erfassung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Der Websitebetreiber hat ein berechtigtes Interesse an der technisch fehlerfreien Darstellung und der Optimierung seiner Website - hierzu müssen die Server-Log-Files erfasst werden.
 
 ### Anfrage per E-Mail, Telefon oder Telefax
 
@@ -161,7 +161,7 @@ Wenn Sie uns per E-Mail, Telefon oder Telefax kontaktieren, wird Ihre Anfrage in
 
 Die Verarbeitung dieser Daten erfolgt auf Grundlage von Art. 6 Abs. 1 lit. b DSGVO, sofern Ihre Anfrage mit der Erfüllung eines Vertrags zusammenhängt oder zur Durchführung vorvertraglicher Maßnahmen erforderlich ist. In allen übrigen Fällen beruht die Verarbeitung auf unserem berechtigten Interesse an der effektiven Bearbeitung der an uns gerichteten Anfragen (Art. 6 Abs. 1 lit. f DSGVO) oder auf Ihrer Einwilligung (Art. 6 Abs. 1 lit. a DSGVO) sofern diese abgefragt wurde; die Einwilligung ist jederzeit widerrufbar.
 
-Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (z. B. nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen – insbesondere gesetzliche Aufbewahrungsfristen – bleiben unberührt.
+Die von Ihnen an uns per Kontaktanfragen übersandten Daten verbleiben bei uns, bis Sie uns zur Löschung auffordern, Ihre Einwilligung zur Speicherung widerrufen oder der Zweck für die Datenspeicherung entfällt (z.B. nach abgeschlossener Bearbeitung Ihres Anliegens). Zwingende gesetzliche Bestimmungen - insbesondere gesetzliche Aufbewahrungsfristen - bleiben unberührt.
 
 ## 5\. Kartenmaterial
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
         className={cn(
           GeistSans.className,
           'antialiased radix-themes radix-themes-custom-fonts font-sans',
-          'min-h-screen flex flex-col', // Added flex layout
+          'min-h-screen flex flex-col',
         )}
         data-is-root-theme="true"
         data-accent-color="indigo"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,8 @@ export default function RootLayout({
       <body
         className={cn(
           GeistSans.className,
-          'antialiased radix-themes radix-themes-custom-fonts font-sans h-screen overflow-y-auto',
+          'antialiased radix-themes radix-themes-custom-fonts font-sans',
+          'min-h-screen flex flex-col', // Added flex layout
         )}
         data-is-root-theme="true"
         data-accent-color="indigo"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import { Map } from '@/components/map/Map'
 
 export default function Home() {
   return (
-    <main>
+    <main className="flex-grow flex">
       <Map />
     </main>
   )

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -3,11 +3,17 @@ import Link from 'next/link'
 const Footer: React.FC = () => {
   return (
     <footer className="w-full py-2 px-4 bg-background text-gray-12 text-center">
-      <div className="text-sm font-medium">
-        <Link href="/privacy" className="px-2 hover:text-indigo-12">
+      <div className="flex justify-center text-sm font-medium gap-x-1">
+        <Link
+          href="/privacy"
+          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-indigo-12"
+        >
           Datenschutz
         </Link>
-        <Link href="/imprint" className="px-2 hover:text-indigo-12">
+        <Link
+          href="/imprint"
+          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-indigo-12"
+        >
           Impressum
         </Link>
       </div>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,23 +2,23 @@ import Link from 'next/link'
 
 const Footer: React.FC = () => {
   return (
-    <footer className="w-full py-2 px-4 bg-[--gray-1] text-[--gray-12] text-center">
-      <div className="flex justify-center text-sm font-medium gap-x-1">
+    <footer className="flex flex-col gap-2 w-full p-6 pb-10 bg-[--gray-1] text-[--gray-12] text-center">
+      <div className="flex justify-center text-sm font-medium gap-4">
         <Link
           href="/privacy"
-          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-[--indigo-11]"
+          className="transition-all ease-in-out duration-300 hover:tracking-wide hover:text-[--indigo-11]"
         >
           Datenschutz
         </Link>
         <Link
           href="/imprint"
-          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-[--indigo-11]"
+          className="transition-all ease-in-out duration-300 hover:tracking-wide hover:text-[--indigo-11]"
         >
           Impressum
         </Link>
       </div>
-      <div className="space-x-6 mt-4 text-sm font-medium">
-        <p>&copy; {new Date().getFullYear()} WaterGuardian</p>
+      <div className="text-sm font-medium">
+        &copy; {new Date().getFullYear()} WaterGuardian
       </div>
     </footer>
   )

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,19 @@
+import Link from 'next/link'
+
 const Footer: React.FC = () => {
   return (
-    <footer className="w-full p-4 bg-background text-gray-12 text-center">
-      <p>&copy; {new Date().getFullYear()} WaterGuardian</p>
+    <footer className="w-full py-2 px-4 bg-background text-gray-12 text-center">
+      <div className="text-sm font-medium">
+        <Link href="/privacy" className="px-2 hover:text-indigo-12">
+          Datenschutz
+        </Link>
+        <Link href="/imprint" className="px-2 hover:text-indigo-12">
+          Impressum
+        </Link>
+      </div>
+      <div className="space-x-6 mt-4 text-sm font-medium">
+        <p>&copy; {new Date().getFullYear()} WaterGuardian</p>
+      </div>
     </footer>
   )
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -2,17 +2,17 @@ import Link from 'next/link'
 
 const Footer: React.FC = () => {
   return (
-    <footer className="w-full py-2 px-4 bg-background text-gray-12 text-center">
+    <footer className="w-full py-2 px-4 bg-[--gray-1] text-[--gray-12] text-center">
       <div className="flex justify-center text-sm font-medium gap-x-1">
         <Link
           href="/privacy"
-          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-indigo-12"
+          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-[--indigo-11]"
         >
           Datenschutz
         </Link>
         <Link
           href="/imprint"
-          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-indigo-12"
+          className="transition-all ease-in-out duration-300 p-2 hover:tracking-wide px-2 hover:text-[--indigo-11]"
         >
           Impressum
         </Link>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -18,8 +18,11 @@ const Header: React.FC = () => {
         </div>
 
         {/* Navigation Links */}
-        <div className="hidden md:flex space-x-6 text-sm font-medium">
-          <Link href="/about" className="hover:text-indigo-12">
+        <div className="hidden md:flex space-x-6 text-sm uppercase font-bold">
+          <Link
+            href="/about"
+            className="transition-all ease-in-out duration-300 hover:text-indigo-12 p-2 hover:tracking-wide"
+          >
             About
           </Link>
         </div>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -8,7 +8,7 @@ const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
-    <header className="w-full bg-background text-gray-12 sticky top-0 z-10">
+    <header className="w-full bg-white text-gray-12 shadow-md sticky top-0 z-10">
       <nav className="flex justify-between items-center p-4 max-w-7xl mx-auto">
         {/* Logo */}
         <div className="flex items-center">
@@ -19,14 +19,8 @@ const Header: React.FC = () => {
 
         {/* Navigation Links */}
         <div className="hidden md:flex space-x-6 text-sm font-medium">
-          <Link href="/" className="hover:underline">
-            Home
-          </Link>
-          <Link href="/about" className="hover:underline">
+          <Link href="/about" className="hover:text-indigo-12">
             About
-          </Link>
-          <Link href="/privacy" className="hover:underline">
-            Impressum & Datenschutz
           </Link>
         </div>
 
@@ -50,18 +44,8 @@ const Header: React.FC = () => {
         <div className="md:hidden bg-background text-gray-12 p-4">
           <ul className="space-y-4 focus:outline-none">
             <li>
-              <Link href="/" onClick={() => setIsMenuOpen(false)}>
-                Home
-              </Link>
-            </li>
-            <li>
               <Link href="/about" onClick={() => setIsMenuOpen(false)}>
                 About
-              </Link>
-            </li>
-            <li>
-              <Link href="/privacy" onClick={() => setIsMenuOpen(false)}>
-                Impressum & Datenschutz
               </Link>
             </li>
           </ul>

--- a/components/header/Header.tsx
+++ b/components/header/Header.tsx
@@ -8,7 +8,7 @@ const Header: React.FC = () => {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
 
   return (
-    <header className="w-full bg-white text-gray-12 shadow-md sticky top-0 z-10">
+    <header className="w-full bg-[--gray-1] text-[--gray-11] shadow-md sticky top-0 z-10">
       <nav className="flex justify-between items-center p-4 max-w-7xl mx-auto">
         {/* Logo */}
         <div className="flex items-center">
@@ -21,7 +21,7 @@ const Header: React.FC = () => {
         <div className="hidden md:flex space-x-6 text-sm uppercase font-bold">
           <Link
             href="/about"
-            className="transition-all ease-in-out duration-300 hover:text-indigo-12 p-2 hover:tracking-wide"
+            className="transition-all ease-in-out duration-300 hover:text-[--accent-12] p-2 hover:tracking-wide"
           >
             About
           </Link>
@@ -35,19 +35,23 @@ const Header: React.FC = () => {
             aria-label="Toggle navigation menu"
           >
             {/* Hamburger Icon */}
-            <span className="block w-6 h-0.5 border border-gray-12 mb-1"></span>
-            <span className="block w-6 h-0.5 border border-gray-12 mb-1"></span>
-            <span className="block w-6 h-0.5 border border-gray-12"></span>
+            <span className="block w-6 h-0.5 bg-[--gray-11] mb-1"></span>
+            <span className="block w-6 h-0.5 bg-[--gray-11] mb-1"></span>
+            <span className="block w-6 h-0.5 bg-[--gray-11]"></span>
           </button>
         </div>
       </nav>
 
       {/* Mobile Menu */}
       {isMenuOpen && (
-        <div className="md:hidden bg-background text-gray-12 p-4">
+        <div className="md:hidden bg-[--gray-1] text-[--gray-11] p-4">
           <ul className="space-y-4 focus:outline-none">
             <li>
-              <Link href="/about" onClick={() => setIsMenuOpen(false)}>
+              <Link
+                href="/about"
+                onClick={() => setIsMenuOpen(false)}
+                className="hover:text-[--indigo-11]"
+              >
                 About
               </Link>
             </li>

--- a/components/map/FilterPopover.tsx
+++ b/components/map/FilterPopover.tsx
@@ -57,15 +57,15 @@ export const FilterPopover = ({
       }}
     >
       <PopoverTrigger asChild>
-        <button className="absolute bottom-12 right-4 p-2 bg-white rounded-full shadow-md z-50">
+        <button className="absolute bottom-12 right-4 p-2 bg-[--gray-1] rounded-full shadow-md z-50">
           <span className="sr-only">Open filters</span>
-          <LayersIcon />
+          <LayersIcon className="text-[--gray-11]" />
         </button>
       </PopoverTrigger>
       <Portal>
         <PopoverContent
           className={cn(
-            'p-4 right-4 bg-white rounded-lg shadow-lg z-50',
+            'p-4 right-4 bg-[--gray-1] rounded-lg shadow-lg z-50',
             'duration-300',
             'data-[state=open]:animate-in data-[state=open]:fade-in data-[state=open]:slide-in-from-bottom-[100%]',
             'data-[state=closed]:animate-out data-[state=closed]:fade-out data-[state=closed]:slide-out-to-bottom-[100%]',
@@ -74,7 +74,9 @@ export const FilterPopover = ({
           align="end"
           sideOffset={4}
         >
-          <h3 className="text-lg font-bold mb-4">Filter Daten</h3>
+          <h3 className="text-lg font-bold text-[--gray-12] mb-4">
+            Filter Daten
+          </h3>
           {types.map((type) => {
             const Icon = type.icon
             const isSelected = selectedTypes.includes(type.id)
@@ -87,20 +89,20 @@ export const FilterPopover = ({
                   <div
                     className={cn(
                       'w-8 h-8 mr-1 flex items-center justify-center rounded-full transition-colors',
-                      isSelected ? 'bg-indigo-6' : 'bg-indigo-3',
+                      isSelected ? 'bg-[--indigo-6]' : 'bg-[--indigo-3]',
                     )}
                   >
                     <Icon
                       className={cn(
                         'w-5 h-5 transition-colors',
-                        isSelected ? 'text-indigo-12' : 'text-gray-11',
+                        isSelected ? 'text-[--indigo-12]' : 'text-[--gray-11]',
                       )}
                     />
                   </div>
                   <span
                     className={cn(
                       'transition-colors',
-                      isSelected ? 'text-gray-11' : 'text-gray-10',
+                      isSelected ? 'text-[--gray-11]' : 'text-[--gray-10]',
                     )}
                   >
                     {type.label}
@@ -110,13 +112,13 @@ export const FilterPopover = ({
                   checked={isSelected}
                   onCheckedChange={() => handleCheckboxChange(type.id)}
                   className={cn(
-                    'w-5 h-5 ml-2 border border-gray-6 rounded transition-colors',
-                    isSelected ? 'bg-indigo-11' : 'bg-indigo-6',
-                    'hover:bg-indigo-7 active:bg-indigo-8',
+                    'w-5 h-5 ml-2 border border-[--gray-6] rounded transition-colors',
+                    isSelected ? 'bg-[--indigo-11]' : 'bg-[--indigo-6]',
+                    'hover:bg-[--indigo-7] active:bg-[--indigo-8]',
                   )}
                 >
                   <CheckboxIndicator>
-                    <CheckIcon className="text-white font-black" />
+                    <CheckIcon className="text-[--gray-1]" />
                   </CheckboxIndicator>
                 </Checkbox>
               </div>

--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -48,19 +48,11 @@ export const Map = () => {
   }
 
   if (!map) {
-    return (
-      <div
-        className="relative w-screen h-[70vh] md:h-[80vh]"
-        ref={mapContainerRef}
-      ></div>
-    )
+    return <div className="flex-1 relative w-full" ref={mapContainerRef}></div>
   }
 
   return (
-    <div
-      className="relative w-screen h-[70vh] md:h-[80vh]"
-      ref={mapContainerRef}
-    >
+    <div className="flex-1 relative w-full" ref={mapContainerRef}>
       <FilterPopover
         onFilterChange={handleFilterChange}
         onOpen={handleFilterOpen}

--- a/components/map/Map.tsx
+++ b/components/map/Map.tsx
@@ -49,12 +49,18 @@ export const Map = () => {
 
   if (!map) {
     return (
-      <div className="relative w-screen h-[80vh]" ref={mapContainerRef}></div>
+      <div
+        className="relative w-screen h-[70vh] md:h-[80vh]"
+        ref={mapContainerRef}
+      ></div>
     )
   }
 
   return (
-    <div className="relative w-screen h-[80vh]" ref={mapContainerRef}>
+    <div
+      className="relative w-screen h-[70vh] md:h-[80vh]"
+      ref={mapContainerRef}
+    >
       <FilterPopover
         onFilterChange={handleFilterChange}
         onOpen={handleFilterOpen}
@@ -79,28 +85,28 @@ export const Map = () => {
         {selectedFeature ? (
           <div className="space-y-6">
             <div>
-              <div className="text-sm font-semibold text-gray-10 mb-1">
+              <div className="text-sm font-semibold text-[--gray-10] mb-1">
                 Data Type
               </div>
-              <div className="text-gray-12">
+              <div className="text-[--gray-12]">
                 {typeLabels[selectedFeature.properties.type]}
               </div>
             </div>
 
             <div>
-              <div className="text-sm font-semibold text-gray-10 mb-1">
+              <div className="text-sm font-semibold text-[--gray-10] mb-1">
                 Location ID
               </div>
-              <div className="text-gray-12 font-mono">
+              <div className="text-[--gray-12] font-mono">
                 {selectedFeature.properties.id}
               </div>
             </div>
 
             <div>
-              <div className="text-sm font-semibold text-gray-10 mb-1">
+              <div className="text-sm font-semibold text-[--gray-10] mb-1">
                 Measurement Date
               </div>
-              <div className="text-gray-12">
+              <div className="text-[--gray-12]">
                 {new Date(selectedFeature.properties.date).toLocaleString(
                   'de-DE',
                   {
@@ -112,10 +118,10 @@ export const Map = () => {
             </div>
 
             <div>
-              <div className="text-sm font-semibold text-gray-10 mb-1">
+              <div className="text-sm font-semibold text-[--gray-10] mb-1">
                 Measurements
               </div>
-              <div className="bg-gray-2 rounded-lg p-4">
+              <div className="bg-[--gray-2] rounded-lg p-4">
                 <ul className="space-y-3">
                   {Object.entries(selectedFeature.properties.measurements).map(
                     ([key, value]) => (
@@ -123,12 +129,12 @@ export const Map = () => {
                         key={key}
                         className="flex items-center justify-between"
                       >
-                        <span className="text-gray-11">{key}</span>
+                        <span className="text-[--gray-11]">{key}</span>
                         <div className="flex items-center gap-2">
-                          <span className="text-gray-12 font-medium">
+                          <span className="text-[--gray-12] font-medium">
                             {value}
                           </span>
-                          <span className="text-sm text-gray-10">mg/L</span>
+                          <span className="text-sm text-[--gray-10]">mg/L</span>
                         </div>
                       </li>
                     ),
@@ -138,7 +144,7 @@ export const Map = () => {
             </div>
           </div>
         ) : (
-          <p className="text-gray-11">No data selected</p>
+          <p className="text-[--gray-11]">No data selected</p>
         )}
       </Sidebar>
     </div>

--- a/components/map/Sidebar.tsx
+++ b/components/map/Sidebar.tsx
@@ -30,18 +30,19 @@ export const Sidebar = ({ open, onClose, children }: SidebarProps) => {
     <div
       className={cn(
         'absolute top-4 right-4 z-40',
-        'h-fit w-80 bg-gray-1 border-l border-gray-6',
+        'h-fit w-80',
         'shadow-lg p-4',
         'rounded-xl overflow-y-auto',
         'duration-300',
+        'bg-[--gray-1]',
         open
           ? 'animate-in fade-in slide-in-from-right-[100%]'
           : 'animate-out fade-out slide-out-to-right-[100%]',
       )}
     >
-      <h2 className="text-lg font-bold text-gray-12">Aktuelle Daten</h2>
+      <h2 className="text-lg font-bold text-[--gray-12]">Aktuelle Daten</h2>
 
-      <Separator className="my-6 bg-gray-6 h-px w-full" />
+      <Separator className="my-4 bg-[--gray-6] h-px w-full" />
 
       <button
         onClick={onClose}
@@ -49,8 +50,9 @@ export const Sidebar = ({ open, onClose, children }: SidebarProps) => {
           'absolute top-2 right-2',
           'h-6 w-6 rounded-full',
           'flex items-center justify-center',
-          'text-gray-11 hover:text-gray-12',
-          'hover:bg-gray-3',
+          'text-[--gray-11]',
+          'hover:text-[--gray-12]',
+          'hover:bg-[--gray-3]',
           'transition-colors duration-300',
         )}
         aria-label="Close"
@@ -58,7 +60,7 @@ export const Sidebar = ({ open, onClose, children }: SidebarProps) => {
         <Cross2Icon />
       </button>
 
-      <div className="text-gray-11">{children}</div>
+      <div className="text-[--gray-11]">{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
- Added real content to the imprint and privacy pages.  
- Improved the navigation in the header and footer.  
- Improved layout structure for map and content 
- Created separate layouts for map and content pages
- Updated map component to use flex-grow for full viewport height
- Moved map page to dedicated route group
- Added proper content page layout with max-width and padding
- Looking forward to updating the about page.  
To achieve this, I will open another issue to create a minimalistic design for the about page and develop the necessary MDX components.

closes #11 